### PR TITLE
feat: add ingest autopost endpoint

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,9 +11,7 @@ if ($method === 'GET' && $uri === '/health') {
 }
 
 if ($method === 'POST' && $uri === '/api/autopost/ingest') {
-    requireBearer($_ENV['AUTOMATION_TOKEN'] ?? '');
-    $controller = new App\Controllers\IngestController();
-    $controller();
+    \App\Controllers\IngestController::ingest();
     return;
 }
 

--- a/src/controllers/IngestController.php
+++ b/src/controllers/IngestController.php
@@ -1,11 +1,116 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controllers;
+
+use App\Models\Queue;
+use RuntimeException;
 
 class IngestController
 {
-    public function __invoke(): void
+    public static function ingest(): void
     {
-        json(200, ['message' => 'ingest stub']);
+        requireBearer($_ENV['AUTOMATION_TOKEN'] ?? '');
+
+        $input = jsonInput();
+
+        $title = $input['title'] ?? null;
+        if (!is_string($title) || $title === '') {
+            json(400, 'Invalid title');
+            return;
+        }
+
+        $summary = $input['summary'] ?? null;
+        if (!is_string($summary) || $summary === '') {
+            json(400, 'Invalid summary');
+            return;
+        }
+
+        $link = $input['link'] ?? '';
+        if (!is_string($link) || !filter_var($link, FILTER_VALIDATE_URL)) {
+            json(400, 'Invalid link');
+            return;
+        }
+
+        $channels = $input['channels'] ?? null;
+        if (!is_array($channels) || $channels === []) {
+            json(400, 'Invalid channels');
+            return;
+        }
+        $allowedChannels = ['fb', 'ig', 'twitter', 'telegram'];
+        foreach ($channels as $ch) {
+            if (!in_array($ch, $allowedChannels, true)) {
+                json(400, 'Invalid channels');
+                return;
+            }
+        }
+
+        $publishRaw = $input['publish_at'] ?? null;
+        if ($publishRaw === null) {
+            json(400, 'Invalid publish_at');
+            return;
+        }
+        if (is_numeric($publishRaw)) {
+            $publishAt = gmdate('Y-m-d H:i:s', (int)$publishRaw);
+        } else {
+            $ts = strtotime((string)$publishRaw);
+            if ($ts === false) {
+                json(400, 'Invalid publish_at');
+                return;
+            }
+            $publishAt = gmdate('Y-m-d H:i:s', $ts);
+        }
+
+        $imageUrl = null;
+        if (isset($input['image_url']) && $input['image_url'] !== '') {
+            if (!is_string($input['image_url']) || !filter_var($input['image_url'], FILTER_VALIDATE_URL)) {
+                json(400, 'Invalid image_url');
+                return;
+            }
+            $imageUrl = $input['image_url'];
+        }
+
+        $payload = null;
+        if (isset($input['data'])) {
+            if (!is_array($input['data'])) {
+                json(400, 'Invalid data');
+                return;
+            }
+            $payload = $input['data'];
+        }
+
+        $priority = 0;
+        if (isset($input['priority'])) {
+            if (!is_int($input['priority']) && !ctype_digit((string)$input['priority'])) {
+                json(400, 'Invalid priority');
+                return;
+            }
+            $priority = (int)$input['priority'];
+        }
+
+        $utm = [
+            'campaign' => 'ai_rtp_' . gmdate('Ymd'),
+            'content' => ($payload['game'] ?? '') . '_' . ($payload['jam'] ?? ''),
+        ];
+
+        try {
+            $id = Queue::insert([
+                'title' => $title,
+                'summary' => $summary,
+                'link_url' => $link,
+                'image_url' => $imageUrl,
+                'utm_json' => $utm,
+                'payload_json' => $payload,
+                'channels' => $channels,
+                'publish_at' => $publishAt,
+                'priority' => $priority,
+            ]);
+        } catch (RuntimeException $e) {
+            json(400, $e->getMessage());
+            return;
+        }
+
+        json(200, ['id' => $id]);
     }
 }


### PR DESCRIPTION
## Summary
- add POST /api/autopost/ingest routing
- implement IngestController with validation, auth, and queue insert

## Testing
- `php -l public/index.php`
- `php -l src/controllers/IngestController.php`
- `composer dump-autoload`

------
https://chatgpt.com/codex/tasks/task_e_689c604ca1948331816a4392d3e580f3