### PR TITLE
Add Facebook dispatcher and post logging model

### DIFF
--- a/src/models/Post.php
+++ b/src/models/Post.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+class Post
+{
+    public static function log(int $queueId, string $platform, ?string $platformPostId, string $status, array $response = []): void
+    {
+        $pdo = db();
+        $sql = 'INSERT INTO social_posts (queue_id, platform, platform_post_id, status, response_json, posted_at) '
+            . 'VALUES (:queue_id, :platform, :platform_post_id, :status, :response_json, :posted_at)';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([
+            ':queue_id' => $queueId,
+            ':platform' => $platform,
+            ':platform_post_id' => $platformPostId,
+            ':status' => $status,
+            ':response_json' => json_encode($response, JSON_UNESCAPED_UNICODE),
+            ':posted_at' => $status === 'posted' ? date('Y-m-d H:i:s') : null,
+        ]);
+    }
+}

--- a/src/services/Dispatcher/Facebook.php
+++ b/src/services/Dispatcher/Facebook.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Dispatcher;
+
+class Facebook
+{
+    public static function postPhoto(string $pageId, string $pageToken, string $imageUrl, string $caption): array
+    {
+        $endpoint = "https://graph.facebook.com/v18.0/{$pageId}/photos";
+
+        $ch = curl_init($endpoint);
+        $postFields = [
+            'url' => $imageUrl,
+            'caption' => $caption,
+            'access_token' => $pageToken,
+        ];
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => http_build_query($postFields),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 15,
+            CURLOPT_CONNECTTIMEOUT => 15,
+        ]);
+
+        $response = curl_exec($ch);
+
+        if ($response === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            return ['ok' => false, 'error' => $error, 'raw' => null];
+        }
+
+        $httpCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        $json = json_decode($response, true);
+
+        if ($httpCode === 200 && isset($json['id'])) {
+            return ['ok' => true, 'id' => $json['id'], 'raw' => $json];
+        }
+
+        $errorMsg = $json['error']['message'] ?? "HTTP {$httpCode}";
+        return ['ok' => false, 'error' => $errorMsg, 'raw' => $json];
+    }
+}


### PR DESCRIPTION
## Summary
- add Facebook dispatcher for posting photos via Graph API
- add Post model for logging platform responses

## Testing
- `php -l src/services/Dispatcher/Facebook.php`
- `php -l src/models/Post.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_689c65757a248331afec58333a885366