### PR TITLE
Add queue processor worker with platform dispatch and retries

### DIFF
--- a/src/Contracts/DispatcherInterface.php
+++ b/src/Contracts/DispatcherInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Exceptions\PlatformException;
+
+interface DispatcherInterface
+{
+    /**
+     * Dispatch a payload to a social platform.
+     *
+     * @param array $payload Structured data for the platform
+     * @return array{post_id:?string, response?:mixed}
+     *
+     * @throws PlatformException
+     */
+    public function post(array $payload): array;
+}

--- a/src/Dispatcher/FacebookDispatcher.php
+++ b/src/Dispatcher/FacebookDispatcher.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dispatcher;
+
+use App\Contracts\DispatcherInterface;
+
+class FacebookDispatcher implements DispatcherInterface
+{
+    public function post(array $payload): array
+    {
+        return ['post_id' => 'fb_' . uniqid()];
+    }
+}

--- a/src/Dispatcher/InstagramDispatcher.php
+++ b/src/Dispatcher/InstagramDispatcher.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dispatcher;
+
+use App\Contracts\DispatcherInterface;
+
+class InstagramDispatcher implements DispatcherInterface
+{
+    public function post(array $payload): array
+    {
+        return ['post_id' => 'ig_' . uniqid()];
+    }
+}

--- a/src/Dispatcher/TelegramDispatcher.php
+++ b/src/Dispatcher/TelegramDispatcher.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dispatcher;
+
+use App\Contracts\DispatcherInterface;
+
+class TelegramDispatcher implements DispatcherInterface
+{
+    public function post(array $payload): array
+    {
+        return ['post_id' => 'tg_' . uniqid()];
+    }
+}

--- a/src/Dispatcher/TwitterDispatcher.php
+++ b/src/Dispatcher/TwitterDispatcher.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dispatcher;
+
+use App\Contracts\DispatcherInterface;
+
+class TwitterDispatcher implements DispatcherInterface
+{
+    public function post(array $payload): array
+    {
+        return ['post_id' => 'tw_' . uniqid()];
+    }
+}

--- a/src/Exceptions/PlatformException.php
+++ b/src/Exceptions/PlatformException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Exception;
+
+class PlatformException extends Exception
+{
+    public string $platform;
+    public array $response;
+
+    public function __construct(string $platform, int $code, string $message, array $response = [])
+    {
+        parent::__construct($message, $code);
+        $this->platform = $platform;
+        $this->response = $response;
+    }
+}

--- a/src/Helpers/Config.php
+++ b/src/Helpers/Config.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+use Dotenv\Dotenv;
+
+class Config
+{
+    public static function load(string $basePath): void
+    {
+        if (file_exists($basePath . '/.env')) {
+            $dotenv = Dotenv::createImmutable($basePath);
+            $dotenv->load();
+        }
+    }
+
+    public static function get(string $key, $default = null)
+    {
+        return $_ENV[$key] ?? $default;
+    }
+}

--- a/src/Helpers/Db.php
+++ b/src/Helpers/Db.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+use PDO;
+
+class Db
+{
+    private static ?PDO $pdo = null;
+
+    public static function instance(): PDO
+    {
+        if (self::$pdo === null) {
+            $dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4',
+                Config::get('DB_HOST', 'localhost'),
+                Config::get('DB_NAME', '')
+            );
+            self::$pdo = new PDO($dsn, Config::get('DB_USER', ''), Config::get('DB_PASS', ''), [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        }
+        return self::$pdo;
+    }
+}

--- a/src/Helpers/Lock.php
+++ b/src/Helpers/Lock.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+class Lock
+{
+    private string $file;
+    private $handle = null;
+
+    public function __construct(string $file)
+    {
+        $this->file = $file;
+    }
+
+    public function acquire(): bool
+    {
+        $this->handle = fopen($this->file, 'c');
+        if ($this->handle === false) {
+            return false;
+        }
+        if (!flock($this->handle, LOCK_EX | LOCK_NB)) {
+            fclose($this->handle);
+            $this->handle = null;
+            return false;
+        }
+        ftruncate($this->handle, 0);
+        fwrite($this->handle, (string)getmypid());
+        return true;
+    }
+
+    public function release(): void
+    {
+        if (is_resource($this->handle)) {
+            flock($this->handle, LOCK_UN);
+            fclose($this->handle);
+            $this->handle = null;
+        }
+    }
+}

--- a/src/Worker/QueueProcessor.php
+++ b/src/Worker/QueueProcessor.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Worker;
+
+use App\Contracts\DispatcherInterface;
+use App\Exceptions\PlatformException;
+use App\Helpers\Config;
+use App\Helpers\Db;
+use App\Helpers\Lock;
+use PDO;
+use RuntimeException;
+
+class QueueProcessor
+{
+    private PDO $db;
+    private array $dispatchers = [];
+    private array $backoff = [1 => 5, 2 => 15, 3 => 60];
+
+    public function __construct()
+    {
+        $this->db = Db::instance();
+    }
+
+    public function run(): void
+    {
+        $lockFile = Config::get('WORKER_LOCK', '/tmp/sae_worker.lock');
+        $lock = new Lock($lockFile);
+        if (!$lock->acquire()) {
+            echo "Worker already running\n";
+            return;
+        }
+        try {
+            $jobs = $this->fetchJobs();
+            foreach ($jobs as $job) {
+                $this->processJob($job);
+            }
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function fetchJobs(): array
+    {
+        $sql = "SELECT * FROM social_queue WHERE status IN ('pending','retry') AND publish_at <= NOW() ORDER BY priority DESC, publish_at ASC LIMIT 10";
+        $stmt = $this->db->query($sql);
+        return $stmt->fetchAll();
+    }
+
+    private function processJob(array $job): void
+    {
+        $queueId = (int)$job['id'];
+        $channels = $this->parseChannels((string)$job['channels']);
+        $allSuccess = true;
+
+        foreach ($channels as $platform) {
+            if ($this->isAlreadyPosted($queueId, $platform)) {
+                continue;
+            }
+            try {
+                $dispatcher = $this->getDispatcher($platform);
+                $resp = $dispatcher->post($job);
+                $postId = $resp['post_id'] ?? null;
+                $this->logSuccess($queueId, $platform, $postId, $resp);
+                $this->notify("Posted #{$queueId} to {$platform}");
+            } catch (PlatformException $e) {
+                $allSuccess = false;
+                $this->logError($platform, $e->response);
+                $this->notify("Fail {$platform} #{$queueId}: {$e->getMessage()}");
+            } catch (\Throwable $e) {
+                $allSuccess = false;
+                $this->logError($platform, ['error' => $e->getMessage()]);
+                $this->notify("Fail {$platform} #{$queueId}: {$e->getMessage()}");
+            }
+        }
+
+        if ($allSuccess) {
+            $stmt = $this->db->prepare("UPDATE social_queue SET status='posted' WHERE id=:id");
+            $stmt->execute([':id' => $queueId]);
+        } else {
+            $this->scheduleRetry($job);
+        }
+    }
+
+    private function parseChannels(string $channels): array
+    {
+        $parts = array_filter(array_map('trim', explode(',', $channels)));
+        $mapped = [];
+        foreach ($parts as $p) {
+            $mapped[] = match ($p) {
+                'fb' => 'facebook',
+                'ig' => 'instagram',
+                default => $p,
+            };
+        }
+        return $mapped;
+    }
+
+    private function getDispatcher(string $platform): DispatcherInterface
+    {
+        if (!isset($this->dispatchers[$platform])) {
+            $class = 'App\\Dispatcher\\' . ucfirst($platform) . 'Dispatcher';
+            if (!class_exists($class)) {
+                throw new RuntimeException("Dispatcher for {$platform} not found");
+            }
+            $this->dispatchers[$platform] = new $class();
+        }
+        return $this->dispatchers[$platform];
+    }
+
+    private function isAlreadyPosted(int $queueId, string $platform): bool
+    {
+        $stmt = $this->db->prepare('SELECT COUNT(*) FROM social_posts WHERE queue_id=:qid AND platform=:pf');
+        $stmt->execute([':qid' => $queueId, ':pf' => $platform]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    private function logSuccess(int $queueId, string $platform, ?string $postId, array $resp): void
+    {
+        $stmt = $this->db->prepare('INSERT INTO social_posts (queue_id, platform, platform_post_id, status, response_json, posted_at) VALUES (:qid,:pf,:pid,\'posted\',:resp,NOW())');
+        $stmt->execute([
+            ':qid' => $queueId,
+            ':pf' => $platform,
+            ':pid' => $postId,
+            ':resp' => json_encode($resp, JSON_UNESCAPED_UNICODE),
+        ]);
+    }
+
+    private function logError(string $platform, array $resp): void
+    {
+        $stmt = $this->db->prepare('INSERT INTO webhooks_log (source, payload_json) VALUES (:src,:payload)');
+        $stmt->execute([
+            ':src' => $platform,
+            ':payload' => json_encode($resp, JSON_UNESCAPED_UNICODE),
+        ]);
+    }
+
+    private function scheduleRetry(array $job): void
+    {
+        $queueId = (int)$job['id'];
+        $retry = (int)($job['retry_count'] ?? 0) + 1;
+        if ($retry > 3) {
+            $stmt = $this->db->prepare("UPDATE social_queue SET status='failed', retry_count=:rc, last_attempt_at=NOW() WHERE id=:id");
+            $stmt->execute([':rc' => $retry, ':id' => $queueId]);
+            $this->notify("Job #{$queueId} failed after retries");
+            return;
+        }
+        $minutes = $this->backoff[$retry] ?? end($this->backoff);
+        $stmt = $this->db->prepare("UPDATE social_queue SET status='retry', retry_count=:rc, last_attempt_at=NOW(), publish_at=DATE_ADD(NOW(), INTERVAL :mins MINUTE) WHERE id=:id");
+        $stmt->execute([':rc' => $retry, ':mins' => $minutes, ':id' => $queueId]);
+    }
+
+    private function notify(string $text): void
+    {
+        $token = Config::get('TG_BOT_TOKEN');
+        $chatId = Config::get('TG_CHAT_ID_ALERT');
+        if (!$token || !$chatId) {
+            return;
+        }
+        $endpoint = "https://api.telegram.org/bot{$token}/sendMessage";
+        $postFields = [
+            'chat_id' => $chatId,
+            'text' => $text,
+        ];
+        $ch = curl_init($endpoint);
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => http_build_query($postFields),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 15,
+            CURLOPT_CONNECTTIMEOUT => 15,
+        ]);
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}

--- a/worker.php
+++ b/worker.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use App\Helpers\Config;
+use App\Worker\QueueProcessor;
+
+Config::load(__DIR__);
+
+$worker = new QueueProcessor();
+$worker->run();


### PR DESCRIPTION
## Summary
- add CLI worker bootstrap that loads env and runs queue processor
- implement QueueProcessor with locking, dispatch, retry backoff and Telegram alerts
- provide helpers for config, database, and lock plus dispatcher interface and stubs

## Testing
- `composer dump-autoload`
- `php -l worker.php src/Worker/QueueProcessor.php src/Contracts/DispatcherInterface.php src/Helpers/Lock.php src/Helpers/Db.php src/Helpers/Config.php src/Exceptions/PlatformException.php src/Dispatcher/FacebookDispatcher.php src/Dispatcher/InstagramDispatcher.php src/Dispatcher/TwitterDispatcher.php src/Dispatcher/TelegramDispatcher.php`


------
https://chatgpt.com/codex/tasks/task_e_689c854d04608331aa8216dffd4df7b6