### PR TITLE
Implement retry policy for queue worker

### DIFF
--- a/src/Helpers/RetryPolicy.php
+++ b/src/Helpers/RetryPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+use DateTimeImmutable;
+
+class RetryPolicy
+{
+    public const MAX_RETRY = 3;
+
+    public static function nextSchedule(int $retryCount): DateTimeImmutable
+    {
+        $now = new DateTimeImmutable('now');
+        return match ($retryCount) {
+            0 => $now->modify('+5 minutes'),
+            1 => $now->modify('+15 minutes'),
+            default => $now->modify('+60 minutes'),
+        };
+    }
+}

--- a/tests/Helpers/RetryPolicyTest.php
+++ b/tests/Helpers/RetryPolicyTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+use App\Helpers\RetryPolicy;
+use PHPUnit\Framework\TestCase;
+
+final class RetryPolicyTest extends TestCase
+{
+    public function testNextScheduleDelays(): void
+    {
+        $now = time();
+        $delta0 = RetryPolicy::nextSchedule(0)->getTimestamp() - $now;
+        $delta1 = RetryPolicy::nextSchedule(1)->getTimestamp() - $now;
+        $delta2 = RetryPolicy::nextSchedule(2)->getTimestamp() - $now;
+
+        $this->assertEqualsWithDelta(300, $delta0, 2);
+        $this->assertEqualsWithDelta(900, $delta1, 2);
+        $this->assertEqualsWithDelta(3600, $delta2, 2);
+    }
+}

--- a/tests/Worker/QueueProcessorTest.php
+++ b/tests/Worker/QueueProcessorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Worker;
+
+use App\Helpers\Db;
+use App\Worker\QueueProcessor;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use DateTimeImmutable;
+
+final class QueueProcessorTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('CREATE TABLE social_queue (id INTEGER PRIMARY KEY, channels TEXT, status TEXT, publish_at TEXT, retry_count INTEGER DEFAULT 0, last_attempt_at TEXT)');
+    }
+
+    private function seedDb(): void
+    {
+        $ref = new ReflectionClass(Db::class);
+        $prop = $ref->getProperty('pdo');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->pdo);
+    }
+
+    public function testScheduleRetryUpdatesPublishAt(): void
+    {
+        $this->seedDb();
+        $now = new DateTimeImmutable('now');
+        $stmt = $this->pdo->prepare('INSERT INTO social_queue (id, channels, status, publish_at, retry_count) VALUES (1, "", "pending", ?, 0)');
+        $stmt->execute([$now->format('Y-m-d H:i:s')]);
+
+        $processor = new QueueProcessor();
+        $method = new ReflectionMethod($processor, 'scheduleRetry');
+        $method->setAccessible(true);
+        $method->invoke($processor, ['id' => 1, 'retry_count' => 0]);
+
+        $row = $this->pdo->query('SELECT status, retry_count, publish_at FROM social_queue WHERE id=1')->fetch();
+        $this->assertSame('retry', $row['status']);
+        $this->assertSame(1, (int)$row['retry_count']);
+
+        $expected = $now->modify('+5 minutes')->getTimestamp();
+        $actual = strtotime($row['publish_at']);
+        $this->assertEqualsWithDelta($expected, $actual, 2);
+    }
+
+    public function testScheduleRetryStopsAfterMax(): void
+    {
+        $this->seedDb();
+        $now = new DateTimeImmutable('now');
+        $stmt = $this->pdo->prepare('INSERT INTO social_queue (id, channels, status, publish_at, retry_count) VALUES (2, "", "retry", ?, 3)');
+        $stmt->execute([$now->format('Y-m-d H:i:s')]);
+
+        $processor = new QueueProcessor();
+        $method = new ReflectionMethod($processor, 'scheduleRetry');
+        $method->setAccessible(true);
+        $method->invoke($processor, ['id' => 2, 'retry_count' => 3]);
+
+        $row = $this->pdo->query('SELECT status, retry_count FROM social_queue WHERE id=2')->fetch();
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame(3, (int)$row['retry_count']);
+    }
+}


### PR DESCRIPTION
## Summary
- add centralized `RetryPolicy` helper with exponential backoff logic
- integrate policy into `QueueProcessor` and add dedupe key for idempotent posts
- cover retry scheduling and failure stop with unit tests

## Testing
- `./vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689da00209bc833181a1a57a98f2c05b