### PR TITLE
Implement environment configuration and notification toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,10 @@
-DB_HOST=localhost
-DB_NAME=primesai
+DB_DSN=mysql:host=127.0.0.1;dbname=social_autopost_db;charset=utf8mb4
 DB_USER=root
 DB_PASS=
-APP_KEY=
-API_TOKEN=supersecrettoken
-FB_PAGE_ID=
-FB_PAGE_TOKEN=
-FALLBACK_IMAGE_URL=https://primesai.co/assets/images/default-card.jpg
-TG_BOT_TOKEN=
-TG_CHAT_ID_ALERT=
+
+# Telegram admin notify
+NOTIFY_ENABLED=true
+BOT_TOKEN_ADMIN=123:abc
+CHAT_ID_ADMIN=-100123456789
+
+# FB/IG/Twitter per account will be taken from platform_accounts table

--- a/src/Helpers/Config.php
+++ b/src/Helpers/Config.php
@@ -20,4 +20,13 @@ class Config
     {
         return $_ENV[$key] ?? $default;
     }
+
+    public static function require(string $key): string
+    {
+        $value = trim((string)($_ENV[$key] ?? ''));
+        if ($value === '') {
+            throw new \RuntimeException("Missing required env: {$key}");
+        }
+        return $value;
+    }
 }

--- a/src/Helpers/Db.php
+++ b/src/Helpers/Db.php
@@ -13,11 +13,10 @@ class Db
     public static function instance(): PDO
     {
         if (self::$pdo === null) {
-            $dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4',
-                Config::get('DB_HOST', 'localhost'),
-                Config::get('DB_NAME', '')
-            );
-            self::$pdo = new PDO($dsn, Config::get('DB_USER', ''), Config::get('DB_PASS', ''), [
+            $dsn = Config::require('DB_DSN');
+            $user = Config::require('DB_USER');
+            $pass = Config::get('DB_PASS', '');
+            self::$pdo = new PDO($dsn, $user, $pass, [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
             ]);

--- a/src/Worker/QueueProcessor.php
+++ b/src/Worker/QueueProcessor.php
@@ -148,8 +148,12 @@ class QueueProcessor
 
     private function notify(string $text): void
     {
-        $token = Config::get('TG_BOT_TOKEN');
-        $chatId = Config::get('TG_CHAT_ID_ALERT');
+        $enabled = filter_var((string)Config::get('NOTIFY_ENABLED', 'false'), FILTER_VALIDATE_BOOLEAN);
+        if (!$enabled) {
+            return;
+        }
+        $token = Config::get('BOT_TOKEN_ADMIN');
+        $chatId = Config::get('CHAT_ID_ADMIN');
         if (!$token || !$chatId) {
             return;
         }


### PR DESCRIPTION
## Summary
- add Config::require to enforce presence of crucial environment variables
- switch database helper to DSN-based credentials with fail-fast behavior
- adjust QueueProcessor notifications with NOTIFY_ENABLED and admin bot tokens
- document required environment variables in `.env.example`

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689da8ca0b208331b1862c00ee02e161