### PR TITLE
Add worker CLI logging and log rotation

### DIFF
--- a/storage/logs/.gitignore
+++ b/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/worker.php
+++ b/worker.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 require __DIR__ . '/vendor/autoload.php';
 
 use App\Helpers\Config;
+use App\Helpers\Logger;
 use App\Worker\QueueProcessor;
 
 Config::load(__DIR__);
 
+Logger::cli('SAE worker started');
 $worker = new QueueProcessor();
 $worker->run();


### PR DESCRIPTION
## Summary
- log queue processor actions to console and `storage/logs/sae_worker.log`
- rotate worker logs up to 5 files of 5MB each
- echo worker start and job outcomes

## Testing
- `vendor/bin/phpunit tests`
- `tail -n 5 storage/logs/sae_worker.log`


------
https://chatgpt.com/codex/tasks/task_e_689daa4245bc83318ceab3fe2657d1ca