### PR TITLE
feat(health): add /health with token expiry alerts

### DIFF
--- a/public/health.php
+++ b/public/health.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+use App\Services\TokenInspector;
+use App\Services\Notifier;
+
+$tokens = TokenInspector::inspect();
+$now = gmdate('c');
+
+$ok = true;
+$soon = [];
+foreach ($tokens as $platform => $info) {
+    if ($info['expires_in_h'] !== null && $info['expires_in_h'] < 24) {
+        $ok = false;
+        $soon[$platform] = $info;
+    }
+}
+
+if (!empty($soon)) {
+    $lines = [];
+    foreach ($soon as $platform => $info) {
+        $lines[] = sprintf('%s %s expires in %dh', $platform, $info['account'], (int) $info['expires_in_h']);
+    }
+    $message = '[SAE] token expiring: ' . implode(', ', $lines);
+    Notifier::alert($message);
+}
+
+http_response_code($ok ? 200 : 503);
+header('Content-Type: application/json');
+echo json_encode([
+    'ok' => $ok,
+    'time' => $now,
+    'tokens' => $tokens,
+]);

--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,7 @@ if ($basePath && str_starts_with($uri, $basePath)) {
 $uri = rtrim($uri, '/') ?: '/';
 
 if ($method === 'GET' && $uri === '/health') {
-    json(200, ['ok' => true, 'php' => PHP_VERSION]);
+    require __DIR__ . '/health.php';
     return;
 }
 

--- a/src/Services/Notifier.php
+++ b/src/Services/Notifier.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Helpers\Config;
+
+class Notifier
+{
+    public static function alert(string $text): void
+    {
+        $token = Config::get('SAE_TELEGRAM_ALERT_BOT_TOKEN');
+        $chatId = Config::get('SAE_TELEGRAM_ALERT_CHAT_ID');
+
+        if ($token && $chatId) {
+            $endpoint = "https://api.telegram.org/bot{$token}/sendMessage";
+            $payload = [
+                'chat_id' => $chatId,
+                'text' => $text,
+            ];
+            $ch = curl_init($endpoint);
+            curl_setopt_array($ch, [
+                CURLOPT_POST => true,
+                CURLOPT_POSTFIELDS => http_build_query($payload),
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_TIMEOUT => 15,
+                CURLOPT_CONNECTTIMEOUT => 15,
+            ]);
+            curl_exec($ch);
+            curl_close($ch);
+        }
+
+        $logFile = dirname(__DIR__, 2) . '/storage/alerts.log';
+        $line = date('c') . ' ' . $text . PHP_EOL;
+        file_put_contents($logFile, $line, FILE_APPEND);
+    }
+}

--- a/src/Services/TokenInspector.php
+++ b/src/Services/TokenInspector.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Helpers\Db;
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+
+class TokenInspector
+{
+    /**
+     * Inspect platform account tokens and return expiry info per platform.
+     *
+     * @return array<string, array{account: string, expires_at: ?string, expires_in_h: ?int}>
+     */
+    public static function inspect(): array
+    {
+        $pdo = Db::pdo();
+        $stmt = $pdo->query('SELECT platform, name, meta_json FROM platform_accounts WHERE is_active = 1');
+
+        $tokens = [];
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        while ($row = $stmt->fetch()) {
+            $meta = [];
+            if (!empty($row['meta_json'])) {
+                $decoded = json_decode((string) $row['meta_json'], true);
+                if (is_array($decoded)) {
+                    $meta = $decoded;
+                }
+            }
+
+            $expiresAt = $meta['expires_at'] ?? null;
+            $expiresInH = null;
+            if (is_string($expiresAt) && $expiresAt !== '') {
+                try {
+                    $expires = new DateTimeImmutable($expiresAt);
+                    $expiresInH = (int) floor(($expires->getTimestamp() - $now->getTimestamp()) / 3600);
+                } catch (Exception $e) {
+                    $expiresAt = null;
+                }
+            }
+
+            $tokens[$row['platform']] = [
+                'account' => (string) $row['name'],
+                'expires_at' => $expiresAt,
+                'expires_in_h' => $expiresInH,
+            ];
+        }
+
+        return $tokens;
+    }
+}


### PR DESCRIPTION
## Summary
- add TokenInspector for reading token expiry from DB
- add Notifier for Telegram alerts and logging
- add `/health` endpoint returning token info and notifying on imminent expiry
- route `/health` through new script

## Testing
- `./vendor/bin/phpunit tests` *(fails: DB Connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a454765ed88331b5e599af22d8ee10