### PR TITLE
Add DB DSN support, migration runner, and endpoint tests

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,43 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$pdo = App\Helpers\Db::pdo();
+$driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+$pdo->exec('CREATE TABLE IF NOT EXISTS schema_migrations (filename VARCHAR(255) PRIMARY KEY)');
+$applied = $pdo->query('SELECT filename FROM schema_migrations')->fetchAll(PDO::FETCH_COLUMN) ?: [];
+$dir = __DIR__ . '/../migrations';
+$files = glob($dir . '/*.{sql,php}', GLOB_BRACE);
+sort($files);
+$logFile = __DIR__ . '/../storage/migrate.log';
+foreach ($files as $file) {
+    $base = basename($file);
+    if (in_array($base, $applied, true)) {
+        continue;
+    }
+    try {
+        if (str_ends_with($file, '.sql')) {
+            if ($driver === 'sqlite') {
+                continue;
+            }
+            $sql = file_get_contents($file);
+            if ($sql !== false) {
+                $pdo->exec($sql);
+            }
+        } else {
+            require $file;
+        }
+        $stmt = $pdo->prepare('INSERT INTO schema_migrations (filename) VALUES (:f)');
+        $stmt->execute([':f' => $base]);
+        $line = date('c') . " migrated {$base}\n";
+        file_put_contents($logFile, $line, FILE_APPEND);
+        echo $line;
+    } catch (Throwable $e) {
+        $line = date('c') . " failed {$base}: " . $e->getMessage() . "\n";
+        file_put_contents($logFile, $line, FILE_APPEND);
+        fwrite(STDERR, $line);
+        exit(1);
+    }
+}

--- a/public/api/autopost/webhook.php
+++ b/public/api/autopost/webhook.php
@@ -23,7 +23,7 @@ if (!preg_match('/^sha256=([0-9a-fA-F]{64})$/', $signatureHeader, $m)) {
     return;
 }
 
-$raw = file_get_contents('php://input') ?: '';
+$raw = $GLOBALS['__SAE_WEBHOOK_BODY'] ?? file_get_contents('php://input') ?: '';
 $expected = hash_hmac('sha256', $raw, $secret);
 if (!hash_equals($expected, strtolower($m[1]))) {
     http_response_code(401);

--- a/public/go.php
+++ b/public/go.php
@@ -47,4 +47,7 @@ if (!$isBot) {
 
 header('Cache-Control: no-store');
 header('Location: ' . $link['target_url'], true, 302);
-exit;
+if (!defined('SAE_TESTING')) {
+    exit;
+}
+return;

--- a/src/Helpers/Db.php
+++ b/src/Helpers/Db.php
@@ -13,15 +13,19 @@ class Db
     public static function instance(): PDO
     {
         if (self::$pdo === null) {
-            $driver  = Config::get('DB_CONNECTION', 'mysql');
-            $host    = Config::get('DB_HOST', '127.0.0.1');
-            $port    = Config::get('DB_PORT', '3306');
-            $dbname  = Config::get('DB_DATABASE', 'social_autopost_db');
-            $user    = Config::get('DB_USERNAME', 'root');
-            $pass    = Config::get('DB_PASSWORD', '');
+            $dsn  = Config::get('DB_DSN');
+            $user = Config::get('DB_USERNAME', '');
+            $pass = Config::get('DB_PASSWORD', '');
 
-            // DSN sesuai dengan .env
-            $dsn = "{$driver}:host={$host};port={$port};dbname={$dbname};charset=utf8mb4";
+            if (!$dsn) {
+                $driver = Config::get('DB_CONNECTION', 'mysql');
+                $host   = Config::get('DB_HOST', '127.0.0.1');
+                $port   = Config::get('DB_PORT', '3306');
+                $dbname = Config::get('DB_DATABASE', 'social_autopost_db');
+                $dsn    = "{$driver}:host={$host};port={$port};dbname={$dbname};charset=utf8mb4";
+                $user   = Config::get('DB_USERNAME', 'root');
+                $pass   = Config::get('DB_PASSWORD', '');
+            }
 
             try {
                 self::$pdo = new PDO($dsn, $user, $pass, [

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -14,12 +14,19 @@ function db(): PDO
 {
     static $pdo = null;
     if ($pdo === null) {
-        $dsn = sprintf(
-            'mysql:host=%s;dbname=%s;charset=utf8mb4',
-            $_ENV['DB_HOST'] ?? 'localhost',
-            $_ENV['DB_NAME'] ?? ''
-        );
-        $pdo = new PDO($dsn, $_ENV['DB_USER'] ?? '', $_ENV['DB_PASS'] ?? '', [
+        $dsn  = $_ENV['DB_DSN'] ?? null;
+        $user = $_ENV['DB_USER'] ?? '';
+        $pass = $_ENV['DB_PASS'] ?? '';
+        if (!$dsn) {
+            $dsn = sprintf(
+                'mysql:host=%s;dbname=%s;charset=utf8mb4',
+                $_ENV['DB_HOST'] ?? 'localhost',
+                $_ENV['DB_NAME'] ?? ''
+            );
+            $user = $_ENV['DB_USER'] ?? '';
+            $pass = $_ENV['DB_PASS'] ?? '';
+        }
+        $pdo = new PDO($dsn, $user, $pass, [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ]);

--- a/tests/GoEndpointTest.php
+++ b/tests/GoEndpointTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class GoEndpointTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRedirectAndLog(): void
+    {
+        define('SAE_TESTING', true);
+        $_ENV['DB_DSN'] = 'sqlite::memory:';
+        $_ENV['DB_USER'] = '';
+        $_ENV['DB_PASS'] = '';
+        $_ENV['SAE_IP_PEPPER'] = 'pep';
+        $envFile = dirname(__DIR__) . '/.env';
+        file_put_contents($envFile, '');
+        require_once __DIR__ . '/../src/bootstrap.php';
+        $pdo = db();
+        $pdo->exec('CREATE TABLE shortlinks (id INTEGER PRIMARY KEY AUTOINCREMENT, short_id TEXT, target_url TEXT, queue_id INTEGER, platform TEXT)');
+        $pdo->exec('CREATE TABLE metrics_clicks (id INTEGER PRIMARY KEY AUTOINCREMENT, queue_id INTEGER, platform TEXT, short_id TEXT, ip_hash TEXT, user_agent TEXT)');
+        $pdo->prepare('INSERT INTO shortlinks (short_id, target_url, queue_id, platform) VALUES (?,?,?,?)')
+            ->execute(['abc', 'https://example.com', 1, 'fb']);
+
+        $_GET['id'] = 'abc';
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0';
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+
+        ob_start();
+        require __DIR__ . '/../public/go.php';
+        ob_end_clean();
+
+        $this->assertSame(302, http_response_code());
+        $count = (int)$pdo->query('SELECT COUNT(*) FROM metrics_clicks')->fetchColumn();
+        $this->assertSame(1, $count);
+        unlink($envFile);
+    }
+}

--- a/tests/HealthEndpointTest.php
+++ b/tests/HealthEndpointTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services {
+    function curl_init(string $url) { $GLOBALS['telegram_url'] = $url; return fopen('php://memory', 'r'); }
+    function curl_setopt_array($ch, array $opts): void { $GLOBALS['telegram_opts'] = $opts; }
+    function curl_exec($ch) { return true; }
+    function curl_close($ch): void {}
+}
+
+namespace Tests {
+
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+final class HealthEndpointTest extends TestCase
+{
+    public function testHealthAlertsOnExpiringToken(): void
+    {
+        $_ENV['DB_DSN'] = 'sqlite::memory:';
+        $_ENV['DB_USER'] = '';
+       $_ENV['DB_PASS'] = '';
+        $_ENV['SAE_TELEGRAM_ALERT_BOT_TOKEN'] = 't';
+        $_ENV['SAE_TELEGRAM_ALERT_CHAT_ID'] = 'c';
+        $envFile = dirname(__DIR__) . '/.env';
+        file_put_contents($envFile, '');
+        require_once __DIR__ . '/../src/bootstrap.php';
+        $pdo = \App\Helpers\Db::pdo();
+        $pdo->exec('CREATE TABLE platform_accounts (id INTEGER PRIMARY KEY AUTOINCREMENT, platform TEXT, name TEXT, meta_json TEXT, is_active INTEGER)');
+        $expires = (new DateTimeImmutable('+1 hour'))->format(DATE_ATOM);
+        $meta = json_encode(['expires_at' => $expires]);
+        $pdo->prepare('INSERT INTO platform_accounts (platform, name, meta_json, is_active) VALUES (?,?,?,1)')
+            ->execute(['fb', 'acct', $meta]);
+
+        ob_start();
+        require __DIR__ . '/../public/health.php';
+        ob_end_clean();
+
+        $this->assertSame(503, http_response_code());
+        $this->assertSame('https://api.telegram.org/bott/sendMessage', $GLOBALS['telegram_url'] ?? null);
+        http_response_code(200);
+        unlink($envFile);
+    }
+}
+}

--- a/tests/TemplaterTest.php
+++ b/tests/TemplaterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Templater;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class TemplaterTest extends TestCase
+{
+    private string $variantFile;
+
+    protected function setUp(): void
+    {
+        $this->variantFile = dirname(__DIR__) . '/storage/ab_variant_abtest.txt';
+        if (file_exists($this->variantFile)) {
+            unlink($this->variantFile);
+        }
+        $ref = new ReflectionClass(Templater::class);
+        $prop = $ref->getProperty('templates');
+        $prop->setAccessible(true);
+        $prop->setValue([
+            'greeting' => [
+                'A' => 'A {{name}}',
+                'B' => 'B {{name}}',
+            ],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->variantFile)) {
+            unlink($this->variantFile);
+        }
+    }
+
+    public function testRoundRobinVariant(): void
+    {
+        $data = ['name' => 'John', 'job' => ['platform' => 'abtest']];
+        $first = Templater::render('greeting', $data);
+        $second = Templater::render('greeting', $data);
+        $this->assertSame('A John', $first);
+        $this->assertSame('B John', $second);
+    }
+}

--- a/tests/WebhookEndpointTest.php
+++ b/tests/WebhookEndpointTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Helpers\Db;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class WebhookEndpointTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_ENV['SAE_WEBHOOK_SECRET'] = 'secret';
+        $_ENV['DB_DSN'] = 'sqlite::memory:';
+        $_ENV['DB_USERNAME'] = '';
+        $_ENV['DB_PASSWORD'] = '';
+
+        $ref = new ReflectionClass(Db::class);
+        $prop = $ref->getProperty('pdo');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
+
+        require_once __DIR__ . '/../vendor/autoload.php';
+    }
+
+    public function testWebhookEnqueues(): void
+    {
+        $pdo = Db::pdo();
+        $pdo->exec('CREATE TABLE webhooks_log (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT, event_id TEXT, signature TEXT, payload TEXT)');
+        $pdo->exec('CREATE TABLE social_queue (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, summary TEXT, link_url TEXT, image_url TEXT, channels TEXT, status TEXT, publish_at TEXT, retry_count INTEGER, meta TEXT)');
+
+        $body = json_encode([
+            'event_id' => 'evt1',
+            'title' => 'Hello',
+            'content' => 'Body',
+        ], JSON_UNESCAPED_UNICODE);
+        $sig = hash_hmac('sha256', $body, $_ENV['SAE_WEBHOOK_SECRET']);
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['HTTP_X_SIGNATURE'] = 'sha256=' . $sig;
+        $GLOBALS['__SAE_WEBHOOK_BODY'] = $body;
+
+        ob_start();
+        require __DIR__ . '/../public/api/autopost/webhook.php';
+        $out = ob_get_clean();
+        unset($GLOBALS['__SAE_WEBHOOK_BODY']);
+        $data = json_decode($out, true);
+
+        $this->assertSame(202, http_response_code());
+        $this->assertTrue($data['ok']);
+        $count = (int)$pdo->query('SELECT COUNT(*) FROM social_queue')->fetchColumn();
+        $this->assertSame(1, $count);
+        http_response_code(200);
+    }
+}


### PR DESCRIPTION
## Summary
- allow overriding DB connection via `DB_DSN`
- add simple migration runner with logging
- expose webhook body override and test shortlink, templater A/B rotation, and health alert flow

## Testing
- `php -l bin/migrate src/Helpers/Db.php src/bootstrap.php public/go.php public/api/autopost/webhook.php tests/WebhookEndpointTest.php tests/TemplaterTest.php tests/GoEndpointTest.php tests/HealthEndpointTest.php`
- `./vendor/bin/phpunit tests/WebhookEndpointTest.php tests/TemplaterTest.php tests/GoEndpointTest.php tests/HealthEndpointTest.php`
- `./vendor/bin/phpunit tests` *(fails: SQL errors in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a46582a5088331b9959c9d35211214