### PR TITLE
Add Config loader and refresh tests

### DIFF
--- a/src/Helpers/Config.php
+++ b/src/Helpers/Config.php
@@ -9,19 +9,24 @@ class Config
 {
     private static bool $loaded = false;
 
-    private static function ensureLoaded(): void
+    public static function load(string $basePath): void
     {
-        if (self::$loaded) return;
-
-        // root project: .../src/Helpers => naik 2 level
-        $basePath = dirname(__DIR__, 2);
-        $envFile  = $basePath . '/.env';
-
+        if (self::$loaded) {
+            return;
+        }
+        $envFile = rtrim($basePath, '/') . '/.env';
         if (is_file($envFile)) {
             $dotenv = Dotenv::createImmutable($basePath);
             $dotenv->load();
         }
         self::$loaded = true;
+    }
+
+    private static function ensureLoaded(): void
+    {
+        if (!self::$loaded) {
+            self::load(dirname(__DIR__, 2));
+        }
     }
 
     public static function get(string $key, mixed $default = null): mixed

--- a/tests/ErrorClassifierTest.php
+++ b/tests/ErrorClassifierTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use App\Exceptions\PlatformException;
 use App\Helpers\ErrorClassifier;
 use PHPUnit\Framework\TestCase;
 
@@ -11,8 +12,8 @@ final class ErrorClassifierTest extends TestCase
 {
     public function testRetryableStatusCodes(): void
     {
-        $this->assertTrue(ErrorClassifier::isRetryable(500));
-        $this->assertTrue(ErrorClassifier::isRetryable(429));
-        $this->assertFalse(ErrorClassifier::isRetryable(400));
+        $this->assertTrue(ErrorClassifier::isRetryable(new PlatformException('p', 500, 'err')));
+        $this->assertTrue(ErrorClassifier::isRetryable(new PlatformException('p', 429, 'err')));
+        $this->assertFalse(ErrorClassifier::isRetryable(new PlatformException('p', 400, 'err')));
     }
 }

--- a/tests/Worker/QueueProcessorTest.php
+++ b/tests/Worker/QueueProcessorTest.php
@@ -41,7 +41,7 @@ final class QueueProcessorTest extends TestCase
         $processor = new QueueProcessor();
         $method = new ReflectionMethod($processor, 'scheduleRetry');
         $method->setAccessible(true);
-        $method->invoke($processor, ['id' => 1, 'retry_count' => 0]);
+        $method->invoke($processor, ['id' => 1, 'retry_count' => 0], $now);
 
         $row = $this->pdo->query('SELECT status, retry_count, publish_at FROM social_queue WHERE id=1')->fetch();
         $this->assertSame('retry', $row['status']);
@@ -62,7 +62,7 @@ final class QueueProcessorTest extends TestCase
         $processor = new QueueProcessor();
         $method = new ReflectionMethod($processor, 'scheduleRetry');
         $method->setAccessible(true);
-        $method->invoke($processor, ['id' => 2, 'retry_count' => 3]);
+        $method->invoke($processor, ['id' => 2, 'retry_count' => 3], $now);
 
         $row = $this->pdo->query('SELECT status, retry_count FROM social_queue WHERE id=2')->fetch();
         $this->assertSame('failed', $row['status']);


### PR DESCRIPTION
## Summary
- add Config::load to support explicit environment bootstrapping
- align unit tests with current schema and PlatformException signature

## Testing
- `vendor/bin/phpunit tests`
- `composer run doctor` *(fails: DB Connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a590898dcc8331b1b0b2d1e8a416e2